### PR TITLE
Fix syntax error in gRPC example

### DIFF
--- a/python-examples/GRPC_README.md
+++ b/python-examples/GRPC_README.md
@@ -21,17 +21,22 @@ pip install grpcio grpcio-tools
 
 ## Setup
 
-First, generate the gRPC Python code from the proto file:
-
-```bash
-python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. python-examples/grpc_example.proto
-```
-
-Or use the built-in setup command:
+First, navigate to the python-examples directory and generate the gRPC Python code:
 
 ```bash
 cd python-examples
 python grpcio-example.py setup
+```
+
+This generates:
+- `grpc_example_pb2.py` - Protocol buffer message classes
+- `grpc_example_pb2_grpc.py` - gRPC service classes
+
+Alternatively, you can manually generate with:
+
+```bash
+cd python-examples
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. grpc_example.proto
 ```
 
 This generates:


### PR DESCRIPTION
Fixed import statements that used hyphens (python-examples) which are not valid Python identifiers. Updated to use relative imports and proper path handling.

Changes:
- Fixed import statements to work correctly
- Updated proto file generation to use script directory
- Improved setup command with better path handling
- Updated documentation to reflect correct usage
- All proto files now generated in python-examples/ directory

The example now works correctly when run from python-examples/ directory as documented.